### PR TITLE
Unexpectedly high translated character count using Google Translate fix

### DIFF
--- a/Source/Main/UI/Translation/AutoTranslateForm.cs
+++ b/Source/Main/UI/Translation/AutoTranslateForm.cs
@@ -797,6 +797,7 @@
 			{
 				foreach (DataRow row in table.Rows)
 				{
+					items.Clear();
 					if (row != null)
 					{
 						if (bw.CancellationPending)


### PR DESCRIPTION
Added the items.Clear() to AutoTranslateForm.cs
