### PR TITLE
Update ExcelImportController.cs

### DIFF
--- a/Source/RuntimeBusinessLogic/ExportImportExcel/Import/ExcelImportController.cs
+++ b/Source/RuntimeBusinessLogic/ExportImportExcel/Import/ExcelImportController.cs
@@ -599,8 +599,8 @@
         {
             int totalChecksumRows;
             var ps = extractColumnCheckSums(table, out totalChecksumRows);
-
-            if (ps.Count <= 0 || totalChecksumRows != table.Rows.Count - 1)
+            // The following was set to compare totalChecksumRows to count -1 but the header row is already removed in the ExcelLibrary.DatasetHelper.CreateDataSet (using PopulateDataTable(ws) method)
+            if (ps.Count <= 0 || totalChecksumRows != table.Rows.Count)
             {
                 return -1;
             }


### PR DESCRIPTION
The File group Checksums are never being used in the import file because the getChecksumTableColumnIndex would ALWAYS return -1

This would cause the import routine to use name matching which causes problems if you have 2 or more resx files using the same tag name. It would apply the change to ALL same name tags.

Reason:
The condition of totalChecksumRows != table.Rows.Count -1  assumes the header row exists in the table, but it doesn't because of the header row is already removed in the ExcelLibrary.DatasetHelper.CreateDataSet (using PopulateDataTable(ws) method) as it has already created the columns from the header row and ignores it when creating the datarows.

Solution:
if (ps.Count <= 0 || totalChecksumRows != table.Rows.Count)
