### PR TITLE
Update CsProjHelper.cs

### DIFF
--- a/Source/RuntimeBusinessLogic/Helpers/CsProjHelper.cs
+++ b/Source/RuntimeBusinessLogic/Helpers/CsProjHelper.cs
@@ -31,8 +31,7 @@
                 foreach (var currentCsProject in currentCsProjects)
                 {
                     var relativeName = fullName.Replace(currentCsProject.DirectoryPath + @"\", string.Empty);
-                    var resourceFolder =
-                        relativeName.Substring(0, relativeName.LastIndexOf(@"\", StringComparison.Ordinal));
+                    
                     var fileInCsProj = currentCsProject.Items.FirstOrDefault(t => t.EvaluatedInclude == relativeName);
                     if (fileInCsProj != null)
                     {


### PR DESCRIPTION
Fixed a bug that occurs if the .resx file is at the root of the cs project. The line of code in question only assigns a variable that is never used, so I have removed this line.